### PR TITLE
Improve api url to call the server

### DIFF
--- a/tratto/src/main/java/star/tratto/Tratto.java
+++ b/tratto/src/main/java/star/tratto/Tratto.java
@@ -35,7 +35,7 @@ public class Tratto {
     private static final ClassAnalyzer classAnalyzer = ClassAnalyzer.getInstance();
     private static final JavaParser javaParser = JavaParserUtils.getJavaParser();
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String ML_MODEL_API_URL = "http://127.0.0.1:5000/api/next_token?filename=../tratto/src/main/resources/token_datapoints.json";
+    private static final String ML_MODEL_API_URL = String.format("http://127.0.0.1:5000/api/next_token?filename=%s/src/main/resources/token_datapoints.json", System.getProperty("user.dir"));
     public static String CLASS_PATH = "src/main/resources/projects-source/commons-collections4-4.1/raw/src/main/java/org/apache/commons/collections4/BagUtils.java";
     public static String PROJECT_SOURCE_PATH = "src/main/resources/projects-source/commons-collections4-4.1/raw/src/main/java/";
     public static String PROJECT_JAR_PATH = "src/main/resources/projects-packaged/commons-collections4-4.1-jar-with-dependencies.jar";


### PR DESCRIPTION
The manual url did not work on my laptop (it produces a path to the file of the token dataset that does not exist). The change should provide a path that is always valid, independently from the different environments where the user can run the tratto program and the server.